### PR TITLE
fix: Update Rushcliffe Borough Council input elements and flow

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/RushcliffeBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/RushcliffeBoroughCouncil.py
@@ -7,6 +7,7 @@ from selenium.webdriver.support.wait import WebDriverWait
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
+import string
 
 # import the wonderful Beautiful Soup and the URL grabber
 class CouncilClass(AbstractGetBinDataClass):
@@ -37,42 +38,57 @@ class CouncilClass(AbstractGetBinDataClass):
             # Populate postcode field
             inputElement_postcode = driver.find_element(
                 By.ID,
-                "ctl00_ContentPlaceHolder1_FF3518TB",
+                "FF3518-text",
             )
             inputElement_postcode.send_keys(user_postcode)
 
             # Click search button
             driver.find_element(
                 By.ID,
-                "ctl00_ContentPlaceHolder1_FF3518BTN",
+                "FF3518-find",
             ).click()
 
             # Wait for the 'Select address' dropdown to appear and select option matching UPRN
             dropdown = WebDriverWait(driver, 10).until(
                 EC.presence_of_element_located(
-                    (By.ID, "ctl00_ContentPlaceHolder1_FF3518DDL")
+                    (By.ID, "FF3518-list")
                 )
             )
             # Create a 'Select' for it, then select the matching URPN option
             dropdownSelect = Select(dropdown)
-            dropdownSelect.select_by_value("U" + user_uprn)
+            found_uprn = False
+            for o in dropdownSelect.options:
+                ov = o.get_dom_attribute("value")
+                if "U" + user_uprn in ov:
+                    dropdownSelect.select_by_value(ov)
+                    found_uprn = True
+                    break
+
+            if not found_uprn:
+                raise Exception("could not find UPRN " + user_uprn + " in list")
 
             # Wait for the submit button to appear, then click it to get the collection dates
             submit = WebDriverWait(driver, 10).until(
                 EC.presence_of_element_located(
-                    (By.ID, "ctl00_ContentPlaceHolder1_btnSubmit")
+                    (By.ID, "submit-button")
+                )
+            ).click()
+
+            # Wait for the confirmation panel to appear
+            conf_div = WebDriverWait(driver, 10).until(
+                EC.presence_of_element_located(
+                    (By.CLASS_NAME, "ss_confPanel")
                 )
             )
-            submit.click()
 
             soup = BeautifulSoup(driver.page_source, features="html.parser")
 
-            bins_text = soup.find("div", id="ctl00_ContentPlaceHolder1_pnlConfirmation")
+            bins_text = soup.find("div", id="body-content")
 
             if bins_text:
                 results = re.findall(
-                    "Your (.*?) bin will next be collected on (\d\d?\/\d\d?\/\d{4})",
-                    bins_text.find("div", {"class": "ss_confPanel"}).get_text(),
+                    r"Your (.*?) bin will next be collected on (\d\d?\/\d\d?\/\d{4})",
+                    bins_text.get_text(),
                 )
                 if results:
                     for result in results:


### PR DESCRIPTION
Some controls had changed their IDs and the transition to the final panel wasn't being picked up anymore. This also fixes a warning about the use of `\d` in the regex by declaring the string as raw.